### PR TITLE
add support for formatters that change the file directly and send no stdout

### DIFF
--- a/lua/easyformat/config.lua
+++ b/lua/easyformat/config.lua
@@ -56,6 +56,8 @@ end
 
 bt.__index = bt
 
+rawset(config, 'timeout', 100)
+
 function bt.use_default(fts)
   for _, ft in pairs(fts) do
     config[ft] = true
@@ -69,12 +71,20 @@ function bt.__newindex(t, k, v)
   end
   v = type(v) == 'boolean' and {} or v
 
-  conf = vim.tbl_extend('force', conf, v)
-  if vim.fn.executable(conf.cmd) == 0 then
-    vim.notify('[EasyFormat] ' .. config.cmd .. ' not executable', vim.log.levels.Error)
-    return
+  if type(v) == 'table' then
+    conf = vim.tbl_extend('force', conf, v)
+    if not conf.cmd then
+      vim.notify('[EasyFormat] cmd is a necessary key', vim.log.levels.Error)
+      return
+    end
+    if vim.fn.executable(conf.cmd) == 0 then
+      vim.notify('[EasyFormat] ' .. conf.cmd .. ' not executable', vim.log.levels.Error)
+      return
+    end
+    rawset(t, k, conf)
+  else
+    rawset(t, k, v)
   end
-  rawset(t, k, conf)
 end
 
 return setmetatable(config, bt)

--- a/lua/easyformat/config.lua
+++ b/lua/easyformat/config.lua
@@ -70,11 +70,19 @@ function bt.__newindex(t, k, v)
     conf = {}
   end
   v = type(v) == 'boolean' and {} or v
-
-  conf = vim.tbl_extend('force', conf, v)
-  if vim.fn.executable(conf.cmd) == 0 then
-    vim.notify('[EasyFormat] ' .. conf.cmd .. ' not executable', vim.log.levels.Error)
-    return
+  if type(v) == 'table' then
+    conf = vim.tbl_extend('force', conf, v)
+    if not conf.cmd then
+      vim.notify('[EasyFormat] cmd is a necessary key', vim.log.levels.Error)
+      return
+    end
+    if vim.fn.executable(conf.cmd) == 0 then
+      vim.notify('[EasyFormat] ' .. conf.cmd .. ' not executable', vim.log.levels.Error)
+      return
+    end
+    rawset(t, k, conf)
+  else
+    rawset(t, k, v)
   end
 end
 

--- a/lua/easyformat/config.lua
+++ b/lua/easyformat/config.lua
@@ -72,10 +72,6 @@ function bt.__newindex(t, k, v)
   v = type(v) == 'boolean' and {} or v
   if type(v) == 'table' then
     conf = vim.tbl_extend('force', conf, v)
-    if not conf.cmd then
-      vim.notify('[EasyFormat] cmd is a necessary key', vim.log.levels.Error)
-      return
-    end
     if vim.fn.executable(conf.cmd) == 0 then
       vim.notify('[EasyFormat] ' .. conf.cmd .. ' not executable', vim.log.levels.Error)
       return

--- a/lua/easyformat/init.lua
+++ b/lua/easyformat/init.lua
@@ -57,7 +57,7 @@ local function do_fmt(buf)
   end
 
   if searcher(conf.find, buf) then
-    if conf.fname then
+    if conf.fname and conf.args[#conf.args] ~= api.nvim_buf_get_name(buf) then
       conf.args[#conf.args + 1] = api.nvim_buf_get_name(buf)
     end
     fmt:init(vim.tbl_extend('keep', conf, { bufnr = buf }))


### PR DESCRIPTION
for python, we typically use `black` formatter, it doesn't send the formatted lines back, with this PR, we can support for this case by using fs_read. A example config can be:

```lua
      configs.python = {
        cmd = 'black',
        args = {},
        find = false,
        fname = true,
        stdin = false,
        do_not_need_stdout = true,
      }
```